### PR TITLE
feat(ci): produce signed-off + signed commits for sync PRs

### DIFF
--- a/.github/workflows/transyncosaurus.yml
+++ b/.github/workflows/transyncosaurus.yml
@@ -55,7 +55,26 @@ jobs:
         sudo mv /tmp/${hub_filename}/bin/hub /usr/local/bin
         hub --version
       shell: bash
-      
+
+    - name: Configure signed commits
+      env:
+        BOT_SSH_SIGNING_KEY: ${{ secrets.DHIS2_BOT_SSH_SIGNING_KEY }}
+      run: |
+        if [[ -z "$BOT_SSH_SIGNING_KEY" ]]; then
+          echo "::error::Secret DHIS2_BOT_SSH_SIGNING_KEY is not set. See README 'Bot commit signing' section."
+          exit 1
+        fi
+        mkdir -p ~/.ssh && chmod 700 ~/.ssh
+        printf '%s\n' "$BOT_SSH_SIGNING_KEY" > ~/.ssh/signing_key
+        chmod 600 ~/.ssh/signing_key
+        ssh-keygen -y -f ~/.ssh/signing_key > ~/.ssh/signing_key.pub
+        git config --global user.name "dhis2-bot"
+        git config --global user.email "apps@dhis2.org"
+        git config --global gpg.format ssh
+        git config --global user.signingkey ~/.ssh/signing_key.pub
+        git config --global commit.gpgsign true
+      shell: bash
+
     - name: Run the script
       run: ./transyncosaurus_ALL.sh
       shell: bash

--- a/.github/workflows/transyncosaurus_weekly.yml
+++ b/.github/workflows/transyncosaurus_weekly.yml
@@ -33,6 +33,25 @@ jobs:
         hub --version
       shell: bash
 
+    - name: Configure signed commits
+      env:
+        BOT_SSH_SIGNING_KEY: ${{ secrets.DHIS2_BOT_SSH_SIGNING_KEY }}
+      run: |
+        if [[ -z "$BOT_SSH_SIGNING_KEY" ]]; then
+          echo "::error::Secret DHIS2_BOT_SSH_SIGNING_KEY is not set. See README 'Bot commit signing' section."
+          exit 1
+        fi
+        mkdir -p ~/.ssh && chmod 700 ~/.ssh
+        printf '%s\n' "$BOT_SSH_SIGNING_KEY" > ~/.ssh/signing_key
+        chmod 600 ~/.ssh/signing_key
+        ssh-keygen -y -f ~/.ssh/signing_key > ~/.ssh/signing_key.pub
+        git config --global user.name "dhis2-bot"
+        git config --global user.email "apps@dhis2.org"
+        git config --global gpg.format ssh
+        git config --global user.signingkey ~/.ssh/signing_key.pub
+        git config --global commit.gpgsign true
+      shell: bash
+
     - name: Run the script
       run: ./transyncosaurus_ALL.sh
       shell: bash

--- a/README.md
+++ b/README.md
@@ -47,3 +47,40 @@ This is a bash script that performs the following:
   - Loops over all branches that have resources in the project.
     - Merges any translation PRs on that branch
 
+## Bot commit signing
+
+`dhis2-core` (and likely other target repos) require **signed commits with a DCO sign-off** on every commit before a PR is mergeable. Without both, the auto-generated sync PRs sit blocked indefinitely and have to be manually amended.
+
+The `transyncosaurus_ALL.sh` script calls `git commit --signoff` (DCO). For the cryptographic signature, the workflow imports an SSH signing key from a repository secret and configures git to sign every commit.
+
+### One-time setup (requires admin on the `dhis2-bot` GitHub account and on this repo)
+
+1. **Generate an ed25519 SSH key for signing** on a trusted local machine:
+
+   ```bash
+   ssh-keygen -t ed25519 -C "dhis2-bot signing key" -f dhis2-bot-signing -N ""
+   ```
+
+   That produces `dhis2-bot-signing` (private) and `dhis2-bot-signing.pub` (public).
+
+2. **Add the public key to `dhis2-bot`'s GitHub account** as a *signing* key:
+   - https://github.com/settings/keys (while logged in as `dhis2-bot`)
+   - Click **New SSH key**, set **Key type → Signing Key**
+   - Paste the contents of `dhis2-bot-signing.pub`
+
+3. **Add the private key as a secret in this repo** (`dhis2/transifex-ci`):
+   - Settings → Secrets and variables → Actions → New repository secret
+   - Name: `DHIS2_BOT_SSH_SIGNING_KEY`
+   - Value: the full content of `dhis2-bot-signing` (including the `-----BEGIN OPENSSH PRIVATE KEY-----` and `-----END OPENSSH PRIVATE KEY-----` lines)
+
+4. **Delete the local keypair** after both halves are stored remotely:
+
+   ```bash
+   shred -u dhis2-bot-signing dhis2-bot-signing.pub
+   ```
+
+5. **Verify** by running the workflow manually (Actions → Transifex App Sync → Run workflow). The next sync PR's commits should appear as **Verified** on GitHub and pass DCO.
+
+### Rotation
+
+To rotate the signing key, repeat steps 1–4 with a fresh keypair, then remove the old public key from the bot's GitHub signing keys list.

--- a/transyncosaurus_ALL.sh
+++ b/transyncosaurus_ALL.sh
@@ -184,8 +184,11 @@ make_branch_pr() {
     # unset -xv
 
     # commit back to git
+    # The commit is DCO-signed-off (--signoff) and GPG/SSH-signed if the workflow
+    # has configured a signing key (via commit.gpgsign=true in git config).
+    # Without signing, the resulting PRs fail dhis2-core's branch-protection checks.
     git add .
-    git commit -F ${commit_detail}
+    git commit --signoff -F ${commit_detail}
 
     # raise a PR on github (using hub command)
     if [[ $CREATE_PULL_REQUEST == 1 ]]; then


### PR DESCRIPTION
## Summary
Stops auto-generated sync PRs into `dhis2-core` from getting stuck on branch-protection checks. Each bot commit will now carry both a DCO `Signed-off-by` line and a verified cryptographic signature.

## Why
`dhis2-core`'s branch protection requires every commit on a PR to have:
1. A `Signed-off-by: …` trailer (DCO bot check)
2. A verified cryptographic signature (GitHub's "Verified" badge)

The current script does neither. Result: every sync PR (#22628, #23862, #23017, #23861, #23979, #23980, #23981, …) sits at `MERGEABLE/BLOCKED` until someone fetches the branch, runs `git rebase --signoff` locally with their own GPG key, and force-pushes. We did this manually for 4 PRs as part of [DHIS2-19912]; it's a treadmill.

## What this PR changes

| File | Change |
|---|---|
| `transyncosaurus_ALL.sh` | Add `--signoff` to the commit on line 188 |
| `.github/workflows/transyncosaurus.yml` | New step `Configure signed commits` before `Run the script` — imports an SSH signing key from `secrets.DHIS2_BOT_SSH_SIGNING_KEY` and configures git globally to sign every commit |
| `.github/workflows/transyncosaurus_weekly.yml` | Same step added |
| `README.md` | New "Bot commit signing" section documenting the one-time secret setup |

I chose SSH signing (Git ≥ 2.34, GitHub-supported) over GPG because it's simpler operationally — no passphrase handling, ed25519 keys are small, and the GitHub signing-key UI accepts SSH directly. Happy to switch to GPG if there's a project reason to prefer it.

## What an admin needs to do before this is effective

1. Generate an ed25519 SSH key (see README).
2. Register the public half on `dhis2-bot`'s GitHub account as a **Signing Key** (not auth key).
3. Add the private half as `DHIS2_BOT_SSH_SIGNING_KEY` in this repo's Actions secrets.
4. Trigger a manual workflow run to verify the next sync PR's commits show as "Verified" on GitHub.

Step-by-step is in the README under "Bot commit signing".

The workflow will fail-fast with a clear `::error::` if the secret isn't set, so it won't silently produce unsigned commits.

## Note about my own commit
This PR's commit has the DCO sign-off but isn't itself GPG-signed — I assume this repo doesn't enforce signing on its own PRs. If it does, happy to re-amend.

## Test plan
- [ ] Admin adds the `DHIS2_BOT_SSH_SIGNING_KEY` secret per README
- [ ] Manually trigger `transyncosaurus.yml` from the Actions tab
- [ ] Verify the resulting sync PR in `dhis2-core` shows commits as **Verified** and **DCO passed**
- [ ] Confirm the PR can be merged without manual amendment

Context: DHIS2-19912.

AI Assisted

[DHIS2-19912]: https://dhis2.atlassian.net/browse/DHIS2-19912?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ